### PR TITLE
ADR-0004 — Artifact authorship is a trust boundary

### DIFF
--- a/docs/adr/ADR-0004-artifact-author-trust-boundary.md
+++ b/docs/adr/ADR-0004-artifact-author-trust-boundary.md
@@ -1,0 +1,83 @@
+# ADR-0004 — Artifact authorship is a trust boundary
+
+**Status:** accepted — 2026-09-07
+**Source:** the Owner's decision of 2026-09-07, quoted verbatim in `§ The decision as given`. Unlike ADR-0001 through ADR-0003 there is no separate directive file to adapt, so the order itself is kept in this record and the sections below are its ratified form on this repository.
+**Relation to ADR-0001 / ADR-0002 / ADR-0003:** a boundary added **around** the artifact mechanism ADR-0001 established, not a replacement for any part of it. No agent is added, no seat collapsed, no safety floor weakened, and no decision in those records reopened. Artifacts remain the medium; what changes is that reading one now depends on who wrote it.
+
+**Why this record is numbered 0004.** Four sentences across three files state that no ADR-0004 exists — the directive-4 row in `docs/adr/README.md § Contents`, two in ADR-0001 (its stability note and its runtime-findings amendment), and `docs/adr/agent-org-directive-4.md` itself. Every one of them is a statement that a *particular directive* produced no record, because it decided nothing new; none reserves the number. The directive that made them says what admits one: "a new ADR only for a genuinely new decision that belongs in none of the existing records" (`docs/adr/agent-org-directive-4.md` §26). A trust boundary on artifact authorship belongs in none of them, so this is that ADR, taking the next unassigned number as `docs/adr/README.md § Form` requires. Those four sentences read as inexact once this record exists, and they are **not** edited here. Each remains true of the thing it describes — the directive it is about — one of the four is the Owner's verbatim directive text and is unalterable on any branch, and the row this record adds to `docs/adr/README.md § Contents` sits directly beneath the one that could mislead. Rewriting the rest from this branch would touch two more files to change nothing a reader acts on.
+
+## Context
+
+`Caisesiume/TurfGPS` is a **public** repository. That was verified rather than assumed, along with everything else in the table below.
+
+| Checked | Found, 2026-09-07 |
+|---|---|
+| Repository visibility | `gh repo view --json isPrivate,visibility` → `isPrivate: false`, `visibility: PUBLIC`. Any GitHub account can comment on any open pull request. |
+| What authenticates an artifact | Nothing but the artifact's own first key. `agent-handoffs § The structured block comes first` states the design in its own words: "the artifact names itself, rather than the instrument guessing from the author or the wording." |
+| What a consumer retrieves | The selector proposed on PR #187 pages the PR's comments, selects on `startswith("artifact: validation_result")`, and projects each match down to `.body` alone. `.user.login`, `.created_at` and `.id` do not survive that projection. |
+| Whether selection on the author was considered | It was ruled out on the same line: "A consumer selects on the declared class — not on your name, not on your wording" (PR #187, in `@validation-agent`). |
+| Whether hostile input has been seen here | Yes. `#152` records a prompt-injection block observed from outside this project, reported by an agent and still open. |
+| What trust boundary already exists | Exactly one, covering the judge lane only: `turfgps-board-ops § The one thing the fallback must never do` requires a ruling's author to read back as `TheReviewNinja` and makes any other value a stop-and-report. No class of artifact other than a judgment is covered. |
+
+Put together, these are not six observations but one mechanism. A validation result is a comment whose body opens with `artifact: validation_result`; a consumer finds it by that string and reads what follows. **Any account on GitHub can write that string.** `@linus-security-critic` demonstrated it against PR #187: a comment declaring `status: pass` with the live head SHA is read as a pass for gates that nobody ran, by a consumer that has no field left in its hands with which to doubt it. The projection is what closes off the doubt — a consumer that wanted to check provenance could not, because the published command threw the author away before the consumer saw it.
+
+The judge lane shows the shape of the answer, having already needed it. It does not extend to this one: it is a rule about a *verdict's* signature, and a validation result is deliberately not a verdict.
+
+**On the finding IDs cited below.** `@linus-security-critic` filed these as `SEC-02` and `SEC-04` in its review of PR #187. Those identifiers are scoped to that review and are not repository-wide: `ADR-0002 § O17` already discusses a different `SEC-02`, from PR #67, about reverse-proxy exposure. Every reference here therefore names the pull request alongside the code. The findings had not been posted to PR #187 when this record was written — checked 2026-09-07, the PR carried no reviews and no comments — so they are cited by the review that produced them, while the mechanism they describe is verified above against the repository itself.
+
+## The decision as given
+
+The Owner's decision of 2026-09-07, verbatim:
+
+> "Harden the readers, as that option suggest. But it should remain the same way as today, but only add @Caisesiume and @TheReviewNinja as trusted users. All other cases, with other users than them, the agents MUST escalate the input from such user to me in question form to deem it's readiness and correctness. .user.login and created at are still needed and a great approach in addition."
+
+## Decision
+
+### D1 — The allowlist is two names, and for them nothing changes
+
+Artifact authorship is trusted for exactly **`Caisesiume`** and **`TheReviewNinja`**. An artifact authored by either is read exactly as it is read today: the declared class selects it, the body is consumed, and no new step is added on the path that carries all of this repository's real traffic.
+
+This is the Owner's "it should remain the same way as today," and it is a deliberate choice of the cheapest possible hardening. The reader gains a comparison against a two-element list. It gains no policy engine, no signature scheme, and no new artifact class — every one of which would be a larger change to the mechanism than the vector justifies.
+
+The list is closed. Adding a third name is an Owner decision and an amendment to this record, not a judgement any agent makes at read time.
+
+### D2 — Any other author is escalated to the Owner as a question, and is never discarded
+
+An artifact whose author is not on the list is **neither trusted nor dropped**. The agent stops consuming it and puts it to the Owner **in question form**, for the Owner to judge — in the Owner's own terms — "it's readiness and correctness."
+
+**Discarding it would be wrong, and this record says so plainly rather than leaving it to be inferred.** A comment from an account outside the list is not by construction an attack. It may be a legitimate contribution: a reader who reproduced a failure, a passer-by who spotted a real defect, a future collaborator. Silently dropping it makes the repository unable to receive that, and does so invisibly — nobody is told, so nobody can notice the policy is costing something. The one party entitled to decide whether such input is sound is the Owner, and the escalation exists to put it there rather than to have an agent guess in either direction.
+
+Both failure directions are therefore refused. Consuming an unknown author's artifact treats a stranger's claim as a measurement; discarding it silently treats a contribution as noise. The escalation is the only path that resolves neither way on its own.
+
+The escalation travels the route every human-bound question already travels — `handoff-payloads § Escalation packet` for the shape that reaches the Owner, and `handoff-payloads § Structured uncertainty (blocked)` where the agent's own domain cannot settle it. This record adds a trigger to that machinery; it does not add a second channel beside it.
+
+### D3 — The selector retains `.user.login` and `.created_at`
+
+The Owner called this out specifically: "`.user.login` and created at are still needed and a great approach in addition." Any retrieval that a consumer is instructed to run **carries the author and the creation timestamp through to the consumer**. A projection that discards them is a defect, because it removes from the reader the only fields on which D1 and D2 can be decided at all — an allowlist is unenforceable against a body that arrived alone.
+
+`.created_at` earns its place twice. The second use is the ordering gap `@linus-security-critic` filed as `SEC-04` on PR #187: when several results exist at one head SHA, a consumer needs a rule for which one is the result, and a timestamp makes that tie-break computable instead of leaving it to whichever comment the page happened to return first.
+
+**What is normative here is that the three fields survive projection**, not any particular command. The command's one home is the agent definition that publishes it, and this record deliberately does not become a second one — `local-gates § Documentation gates` gate 2 is the reason, and the selector fragments described in `§ Context` above are dated evidence of a shape observed on a specific day, not a copy of the instruction.
+
+### D4 — No artifact is a clearance
+
+An artifact reporting `pass` is **evidence that a measurement was taken**. It is an input to `@pr-judge`'s ruling and never a substitute for it. This holds for artifacts from allowlisted authors too — D1 admits an artifact to being *read*, and admits it to nothing else.
+
+This is the same principle `docs/DELIVERY.md § Escalation and human judgement` already states for the board: "a clean board is a **recommendation to the human**, not an approval." The reason it is restated as a decision rather than left as a citation is that the allowlist creates the temptation it guards against: a trusted author makes a `pass` feel dispositive precisely when the mechanism has just been described as hardened. It has not been. It has been narrowed.
+
+## Consequences
+
+**What this obliges:**
+
+- **Every consumer of a declared artifact acquires a branch it did not have.** Read, escalate, or stop — decided per artifact, on the author. The cost is one comparison against a two-element list on the path that carries essentially all traffic, and this is the cheapest form the decision could take.
+- **Two files must change, and neither changes here.** The reader hardening lands in `@validation-agent` and in `agent-handoffs`, which is exactly the diff PR #187 has open and under judgment. This record was written without touching either: a second writer in a file already being judged is the hazard the one-writer rule exists to prevent, and a decision record that quietly implements itself is not a decision record. The implementation cites this ADR when it lands.
+- **A new stall is possible.** An artifact from an unlisted author now blocks its consumer until the Owner answers. That is a stall by design, and preferable to both alternatives, but it is a real cost and it is the Owner who pays it.
+- **The list is a maintenance surface.** Two names are written into the repository's trust model. An account rename, a new collaborator, or a second review identity is now a change to this record.
+
+**What this gives up:**
+
+- **Authorship on GitHub is not authentication.** An allowlist tests a login, and a login is not a signature. It is what is available without a key-management scheme this project does not have and does not need; it stops an anonymous stranger, which is the vector actually demonstrated.
+- **It does not close the collapse `SEC-02` recorded on PR #187, and pretending otherwise would be the worse outcome.** The default CLI is authenticated as `Caisesiume` — the same account that authors the branches under review. `turfgps-board-ops § The one thing the fallback must never do` names that in its own words for the judgment case: a judgment posted through the plain CLI "would appear as `Caisesiume` — the author approving their own work ... and it would look completely normal in the history." An allowlist admitting `Caisesiume` therefore cannot tell a worker's artifact from the branch author's own tooling, because at the transport layer they are the same account. **The stranger vector is closed. The self-authorship vector is not**, and no widening of this list can close it — a list that admits an identity admits everything wearing it. What answers that one is D4: the artifact is not the clearance, so an artifact that authenticates as the author still buys nothing but a reading.
+- **Nothing is gained against a compromised trusted account**, and the same D4 argument is the only thing standing behind that case too.
+
+**Reversibility: high.** The decision is a comparison and two retained fields. Removing the comparison restores today's behaviour exactly; the retained fields are additive and harm nothing if never read. No data migrates and no artifact already posted becomes invalid.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,3 +32,4 @@ State the cost as well as the benefit. A record that lists only advantages is ad
 | `agent-org-directive-3.md` | Not an ADR — the Owner's third directive of 2026-08-10, kept verbatim as the source order ADR-0003 adapts |
 | `ADR-0003-backlog-dependency-planner.md` | A dedicated owner for the persistent Epic/story dependency graph — the edges leave `@scrum-master`, which now consumes them |
 | `agent-org-directive-4.md` | Not an ADR — the Owner's fourth and final directive of 2026-08-10, kept verbatim. Ratified **into** ADR-0001 (stability rule) and ADR-0003 (amendments A1–A3); per its own §26 no ADR-0004 exists |
+| `ADR-0004-artifact-author-trust-boundary.md` | Artifact authorship is a trust boundary — two trusted logins, an Owner escalation for every other author, and the fields a retrieval must retain. The row above is about directive 4 and stands unaltered; why the number was nonetheless available is argued in that record's header |


### PR DESCRIPTION
```yaml
artifact: worker_report
sha: 69e1cd40b4354c22034e17ae9780f16751aa803d
pr: 188
cycle: 5
prose_licence: predecessor_corrected
supersedes: the cycle-2 body on this PR
```

## ADR-0004 — artifact authorship is a trust boundary

Files: the two ADRs, nothing outside `docs/adr/`, per the packet's boundary. No board item — accepted risk `VAL-01`, carried. No safety path touched: no access classification, stop selection, routing exclusion, time budget or constant feeding them. Stated rather than omitted.

**Fix the class, not the site.** Cycle 2 discharged 14 of 14 at their named lines and 12 reappeared beside them, so the packet's three sweeps were run as greps over the whole record and re-run afterwards. Each is reported with what its re-run returned.

### The three sweeps

| sweep | run | re-run returned |
|---|---|---|
| **1 · dates** | grep `2026-09-17` over both records — 8 sites | No Owner ruling is dated to it anywhere. Every survivor is the revision date, a dated verification, or the withdrawn claim quoted as withdrawn. |
| **2 · attribution** | grep 12 Owner-attribution phrases over both records — 14 sites | 8 corrected, 6 verified true (Ruling 1's own sentences; the selection as the Owner's act). The re-run found **one residual site outside every cited line** — "the narrowing is the Owner's, not theirs" — now split into decision-vs-wording. |
| **3 · verbatim blocks** | every `^> ` block in both records — 5 | All 5 **byte-identical to `#issuecomment-5713681420` unstripped**, checked programmatically. Included Ruling 1's added quotation marks, which no finding named but which made this record's own byte-faithful claim false. |

### The 12 required_change

| id | sev | resolution |
|---|---|---|
| `DOC-07` | high | Sweep 2. The withdrawal's "the Owner's own instruction of 2026-09-17" is gone and quoted only as the withdrawn error; rulings 2 and 3 now carry label-as-Owner's-act vs description-as-`@engineering-lead`'s-proposal; the "each is quoted verbatim" promise is replaced by how each was actually given. Answered by `#issuecomment-5713681420`, cited and quoted from. |
| `SEC-07` | high | Three sites. The inert-data control exists in **no file on disk** — `grep -rn "inert data"` over `.claude/` and `docs/` returns 0 hits outside ADR-0004. Stated **owed, not in force**, with its home named as `handoff-payloads § Escalation packet`. |
| `CORE-01` | high | Recorded in both lanes, implemented in neither — the packet's scope. Both files still enumerate five and close with "nothing else qualifies" (read on disk); `@engineering-lead` is sole sender, so it would read a false exhaustive claim and drop the artifact silently, the one direction `D2` refuses. `§ D2` and `§ D16` **bind nowhere else yet**. `ADR-0001 § D16` **cites** this rather than restating it. |
| `DOC-08` | med | Ground 3 dropped, not reworded. The ruling authorises an amendment and bounds nothing, so the bound is named as **this record's own discipline** — at both sites that leaned on it, not just the cited one. |
| `LA-06` | low | Both `ADR-0001` sentences repaired, one clause each, as README r34 was: each now says the pass produced *no ADR of its own*. |
| `SEC-09` | med | "free and unlimited" retracted — the narrowing removes the **accidental** pager only; deliberate paging stays free, unrated and unpriced. |
| `SEC-11` | med | "is closed" → closes **once the reader hardening lands**. As of 2026-09-17 nothing on any branch compares an author against the list, so the vector is open in the running system. |
| `SEC-10` | med | **Named as residual, not mandated**: the escalating predicate is not required to be a superset of the selecting one, so an artifact-shaped comment nothing retrieves is never escalated. Left to an Owner decision, as `.user.id` and `.updated_at` are. |
| `DOC-09` | low | Sweep 3, above. |
| `DOC-10` | low | Run as a sweep, not an append: the enumeration is checked against the codes the record cites, `DOC-04` added with 15 others, and the sweep rule stated so the list cannot drift again. |
| `LA-07` | low | The `ADR-0001 § D11` citation was inverted — D11 forbids *ending* a pass with a continuation outstanding and expressly permits the persist-and-exit this record uses. Corrected to what D11 says. |
| `DOC-11` | low | Discharged by the artifact; cited at `§ Source` with the `ACCEPTED ON TRUST` history recorded rather than quietly dropped. |

### Every claim checked against disk

| claim | how |
|---|---|
| `DELIVERY.md` enumerates five | read `§ Escalation and human judgement` — five conditions, no sixth |
| `handoff-payloads` closes the list | line 93, "nothing else qualifies", read verbatim |
| `@engineering-lead` inherits it | `engineering-lead.md:3`, `:86`, `:259` — sole sender, §21-only |
| inert-data control exists | repo-wide grep → 0 hits outside ADR-0004 |
| `ADR-0001 § D11` says the opposite | read D11 in full |
| 5 blockquotes byte-faithful | programmatic substring match against the artifact, unstripped |
| quoted source text | `agent-handoffs:29`, `turfgps-board-ops:47`, `DELIVERY.md:324`, `directive-4:111` — all byte-faithful |

### Gates

`make` is absent (#179), so each was run directly; nothing is reported as clean that did not run.

```
refs: 105 checked / 0 unresolved, method: headings | inbound: n/a | duplication: none | mermaid: 0/0 — @validation-agent's run, sha: 69e1cd4 / cycle: 5, dir D:/Website/TurfGPS-wt/review-pr-188, source #issuecomment-5716580097
```

| gate | what ran |
|---|---|
| **1** | Parts run: **resolution**, **delimiter conformance**, **heading citability**, **inbound** — over both ADRs and `docs/adr/README.md`. **Method: headings, for every file.** Neither ADR is on the converted-file list in `docs/README.md § Conventions`, read at run time — all 17 entries are `docs/Requirements/` — so the **pattern check is unlicensed here and was not run**. The 1 unresolved is the pre-existing `§N` notation at `ADR-0001:5`, accepted as `DOC-05`, confirmed untouched (context line only). 0 superseded forms, 0 skill-by-path, 0 uncitable headings. **`inbound: n/a`** — no heading renamed, re-split or emptied; the two `ADR-0001` claims retracted are body lines and a repo-wide grep found nothing citing them. |
| **2** | Automated class: recall corpus first, all passed (held-out recall 0 of 4, as the corpus itself reports), then `d8-root-run-claims: clean · corpus 105 file(s) · surface 12 · part 1: 0 · part 2: 0 flagged, 1 exempted`. **That is one class inside gate 2.** The rest ran by hand and **flagged something I had introduced**: the `D16` addition restated the `CORE-01` obligation instead of citing it, against that entry's own rule. Replaced with a citation. Dated observations about `DELIVERY.md` and `handoff-payloads` are kept as dated evidence, the form this record already uses for the selector. |
| **3** | 0 mermaid blocks in the changed files. `0/0` — not a pass over something. |
| code | Inapplicable: 0 Go, 0 frontend files. Not skipped. |
| red demos | None owed — no test files, no `test`-verified criterion claimed. |

### Not in this diff

| out of scope | why |
|---|---|
| `SEC-12`, `SEC-13` | `future_work`, routed to `@engineering-lead`. Not mine. |
| `@validation-agent`, `agent-handoffs`, selectors | PR #187's. |
| `DELIVERY.md`, `handoff-payloads`, `engineering-lead.md` | The packet discharges `CORE-01` by **recording** it; a second writer in a file under judgment is the hazard the one-writer rule prevents. |

**Merge stays the Owner's call.** `#180` `CHANGES_REQUESTED` stands at `7d4d8fa`; the next judge clears it.
